### PR TITLE
Add support for sanitizing Response data via reflection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7
   - 7.1
   - 7.2
+  - 7.3
+  - nightly
   - hhvm
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@
 
 I got tired of having to always sanitize the data, so this is a quick and dirty solution until php-vcr officially supports "private" recordings.
 
+[TOC levels=4]: # "## Table of Contents"
+
+## Table of Contents
+- [Installation](#installation)
+- [Usage](#usage)
+    - [Configuration](#configuration)
+        - [Sanitizing Requests](#sanitizing-requests)
+        - [Sanitizing Responses](#sanitizing-responses)
+    - [Disabling the Sanitizer](#disabling-the-sanitizer)
+- [How Sanitizing Works](#how-sanitizing-works)
+    - [Hostnames](#hostnames)
+    - [Headers](#headers)
+    - [URL Parameters](#url-parameters)
+    - [Body Content](#body-content)
+- [License](#license)
+
+
 ## Installation
 
 Install the package through [Composer](https://getcomposer.org/).
@@ -26,23 +43,75 @@ VCR::turnOn();
 VCR::insertCassette('...');
 
 VCRCleaner::enable(array(
-    'ignoreUrlParameters' => array(
-        'apiKey',
-    ),
-    'ignoreHeaders' => array(
-        'X-Api-Key',
-    ),
-    'bodyScrubbers' => array(function($body) {
-        return preg_replace('/<password.*<\/password>/', 'REDACTED', $body);
-    }),
+   'request' => array(
+       'ignoreHostname' => false,
+       'ignoreQueryFields' => array(
+           'apiKey',
+       ),
+       'ignoreHeaders' => array(
+           'X-Api-Key',
+       ),
+       'bodyScrubbers' => array(
+           function($body) {
+               return preg_replace('/<password.*<\/password>/', 'hunter2', $body);
+           }
+       ),
+   ),
+   'response' => array(
+       'ignoreHeaders' => array(),
+       'bodyScrubbers' => array(),
+   ),
 ));
 ```
 
-## How it Works
+### Configuration
+
+This library allows your sanitize both the Request and Response sections of your recordings so only non-sensitive data is written to your cassettes. You define the behavior for this sanitizer via an array with configuration options explained below.
+
+#### Sanitizing Requests
+
+- `request.ignoreHostname` - When set to true, the hostname in URLs inside of the Request will be replaced with `[]` in the `url` field and the `Host` in the headers will be set to null.
+- `request.ignoreQueryFields` - Define which GET parameters in your URL to completely strip out of your recordings.
+- `request.ignoreHeaders` - Define the headers in your recording that will automatically be set to null in your recordings
+- `request.bodyScrubbers` - An array of callbacks that will have the request body available as a string. Each callback **must** return the modified body. The callbacks are called consecutively in the order they appear in this array and the value from one callback propagates to the next.
+
+#### Sanitizing Responses
+
+The php-vcr library does not officially support modifying its responses so this library uses reflection to modify the contents of responses. While this feature is officially supported by *this* project, bear with us if this feature were to break due to the php-vcr changing its internals.
+
+- `response.ignoreHeaders` - The same as `request.ignoreHeaders` but for your response body instead.
+- `response.bodyScrubbers` - The same as `request.bodyScrubbers` but for your response body instead.
+
+### Disabling the Sanitizer
+
+Why is there no `VCRCleaner::disable()`? There's no simple and non-hackish way to restore the VCR to its original state. It's probably easier to just configure your VCR differently for a certain batch of unit tests anyways.
+
+## How Sanitizing Works
 
 When VCR is looking for recordings to playback, VCRCleaner uses modified "matchers" to check everything except for the fields you've marked as sensitive.
 
-### Hiding Headers
+### Hostnames
+
+If the hostname of the URL endpoint you're hitting is sensitive and shouldn't be recorded, you can have the sanitizer ignore hostnames and they'll be replaced in the `url` field with a `[]` instead and the `host` header will be set to null.
+
+```yaml
+-
+    request:
+        method: GET
+        url: 'https://[]/search'
+        headers:
+            Host: null
+            X-Type: application/vcr
+    response:
+        status:
+            http_version: '1.1'
+            code: '404'
+            message: 'Not Found'
+        headers: ~
+        body: "...response body..."
+```
+
+### Headers
 
 Let's say you set the `X-Api-Key` header to `SuperToast`. In your recording, the header you specified will be saved as null.
 
@@ -64,7 +133,7 @@ Let's say you set the `X-Api-Key` header to `SuperToast`. In your recording, the
         body: "...response body..."
 ```
 
-### Hiding URL Parameters
+### URL Parameters
 
 Notice how `apiKey=yourSecretApiKey` is stripped away in your recording. During your VCR playback, it'll look for matching requests *without* the `apiKey` parameter.
 
@@ -86,15 +155,15 @@ Notice how `apiKey=yourSecretApiKey` is stripped away in your recording. During 
         body: "...response body..."
 ```
 
-### Hiding body contents
+### Body Content
 
-Unlike ignoring headers or URL parameters, scrubbing information from the request body makes use of an array of callbacks. The result of each function is passed on to the next function.
+Unlike ignoring headers or URL parameters, scrubbing information from both request and response bodies makes use of an array of callbacks. The result of each function is passed on to the next function.
 
-Notice how `<password>Hunter2</password>` has been stripped away from the request body. The callbacks take the body as a string parameter, the modified result has to be returned.
+Notice how `password=hunter2` has been stripped away from the request body. The callbacks take the body as a string parameter, the modified result has to be returned.
 
 ```php
-VCRCleaner::enable(
-    array(
+VCRCleaner::enable(array(
+    'request' => array(
         'bodyScrubbers' => array(
             function ($body) {
                 $parameters = array();
@@ -105,8 +174,8 @@ VCRCleaner::enable(
                 return http_build_query($parameters);
             },
         ),
-    )
-);
+    ),
+));
 ```
 
 ```yaml

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * (c) Copyright 2018 Vladimir Jimenez
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace allejo\VCR;
+
+/**
+ * @internal
+ */
+abstract class Config
+{
+    private static $options = array();
+
+    public static function configureOptions(array $options)
+    {
+        self::$options = array_replace_recursive(self::defaultConfig(), $options);
+    }
+
+    public static function ignoreReqHostname()
+    {
+        return self::$options['request']['ignoreHostname'];
+    }
+
+    public static function getReqIgnoredQueryFields()
+    {
+        return self::$options['request']['ignoreQueryFields'];
+    }
+
+    public static function getReqIgnoredHeaders()
+    {
+        return self::$options['request']['ignoreHeaders'];
+    }
+
+    public static function getReqBodyScrubbers()
+    {
+        return self::$options['request']['bodyScrubbers'];
+    }
+
+    public static function getResIgnoredHeaders()
+    {
+        return self::$options['response']['ignoreHeaders'];
+    }
+
+    public static function getResBodyScrubbers()
+    {
+        return self::$options['response']['bodyScrubbers'];
+    }
+
+    private static function defaultConfig()
+    {
+        return array(
+            'request' => array(
+                'ignoreHostname'    => false,
+                'ignoreQueryFields' => array(),
+                'ignoreHeaders'     => array(),
+                'bodyScrubbers'     => array(),
+            ),
+            'response' => array(
+                'ignoreHeaders'     => array(),
+                'bodyScrubbers'     => array(),
+            ),
+        );
+    }
+}

--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -22,6 +22,8 @@ class RelaxedRequestMatcher
                 'ignoreUrlParameters' => array(),
                 'ignoreHeaders'       => array(),
                 'bodyScrubbers'       => array(),
+                'ignoreResponseHeaders' => array(),
+                'responseBodyScrubbers' => array(),
             ),
             $options
         );
@@ -92,6 +94,7 @@ class RelaxedRequestMatcher
         $converters = self::$options['bodyScrubbers'];
         $firstBody = $first->getBody();
         $secondBody = $second->getBody();
+
         foreach ($converters as $converter) {
             $firstBody = $converter($firstBody);
             $secondBody = $converter($secondBody);

--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -11,7 +11,10 @@ namespace allejo\VCR;
 
 use VCR\Request;
 
-class RelaxedRequestMatcher
+/**
+ * @internal
+ */
+abstract class RelaxedRequestMatcher
 {
     public static function matchQueryString(Request $first, Request $second)
     {

--- a/src/VCRCleaner.php
+++ b/src/VCRCleaner.php
@@ -11,8 +11,30 @@ namespace allejo\VCR;
 
 use VCR\VCR;
 
-class VCRCleaner
+abstract class VCRCleaner
 {
+    /**
+     * Enable the VCR cleaner to sanitize recordings before they are recorded
+     * and enable sanitized recordings to be used in cassettes.
+     *
+     * ```
+     * $options = [
+     *   'request' => [
+     *     'ignoreHostname'    => boolean
+     *     'ignoreQueryFields' => string[]
+     *     'ignoreHeaders'     => string[]
+     *     'bodyScrubbers'     => Array<(string $body): string>
+     *   ],
+     *   'response' => [
+     *     'ignoreHeaders'     => string[]
+     *     'bodyScrubbers'     => Array<(string $body): string>
+     *   ],
+     * ];
+     * ```
+     *
+     * @param array $options An array with the defined structure. All settings
+     *                       have default values.
+     */
     public static function enable(array $options)
     {
         Config::configureOptions($options);

--- a/src/VCRCleaner.php
+++ b/src/VCRCleaner.php
@@ -15,7 +15,7 @@ class VCRCleaner
 {
     public static function enable(array $options)
     {
-        RelaxedRequestMatcher::configureOptions($options);
+        Config::configureOptions($options);
 
         VCR::configure()
             ->addRequestMatcher('headers', array('allejo\VCR\RelaxedRequestMatcher', 'matchHeaders'))

--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -15,6 +15,9 @@ use VCR\Request;
 use VCR\Response;
 use VCR\VCREvents;
 
+/**
+ * @internal
+ */
 class VCRCleanerEventSubscriber implements EventSubscriberInterface
 {
     /**

--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -60,9 +60,7 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeRequestHeaders(Request $request)
     {
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
-
-        foreach ($options['ignoreHeaders'] as $header) {
+        foreach (Config::getReqIgnoredHeaders() as $header) {
             if ($request->hasHeader($header)) {
                 $request->setHeader($header, null);
             }
@@ -71,9 +69,7 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeRequestHost(Request $request)
     {
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
-
-        if (!$options['ignoreHostname']) {
+        if (!Config::ignoreReqHostname()) {
             return;
         }
 
@@ -87,8 +83,6 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeRequestUrl(Request $request)
     {
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
-
         $url = parse_url($request->getUrl());
 
         if (!isset($url['query'])) {
@@ -98,7 +92,7 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
         $queryParts = array();
         parse_str($url['query'], $queryParts);
 
-        foreach ($options['ignoreUrlParameters'] as $urlParameter) {
+        foreach (Config::getReqIgnoredQueryFields() as $urlParameter) {
             unset($queryParts[$urlParameter]);
         }
 
@@ -112,9 +106,8 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
     private function sanitizeRequestBody(Request $request)
     {
         $body = $request->getBody();
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
 
-        foreach ($options['bodyScrubbers'] as $scrubber) {
+        foreach (Config::getReqBodyScrubbers() as $scrubber) {
             $body = $scrubber($body);
         }
 
@@ -123,9 +116,7 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeResponseHeaders(array &$workspace)
     {
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
-
-        foreach ($options['ignoreResponseHeaders'] as $headerToIgnore) {
+        foreach (Config::getResIgnoredHeaders() as $headerToIgnore) {
             if (isset($workspace['headers'][$headerToIgnore])) {
                 $workspace['headers'][$headerToIgnore] = null;
             }
@@ -134,9 +125,7 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeResponseBody(array &$workspace)
     {
-        $options = RelaxedRequestMatcher::getConfigurationOptions();
-
-        foreach ($options['responseBodyScrubbers'] as $bodyScrubber) {
+        foreach (Config::getResBodyScrubbers() as $bodyScrubber) {
             $workspace['body'] = $bodyScrubber($workspace['body']);
         }
     }

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -184,29 +184,26 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         VCRCleaner::enable(array(
             'response' => array(
                 'ignoreHeaders' => array(
-                    'X-Powered-By',
+                    'X-Cache',
                 ),
             ),
         ));
 
         $curl = new Curl();
-        $curl->get('https://reqres.in/api/users/2');
+        $curl->get('https://www.example.com/search');
         $curl->close();
 
         $vcrFile = $this->getCassetteContent();
 
-        $this->assertNotContains('X-Powered-By: Express', $vcrFile);
-        $this->assertContains('X-Powered-By: null', $vcrFile);
+        $this->assertNotContains('X-Cache: 404-HIT', $vcrFile);
+        $this->assertContains('X-Cache: null', $vcrFile);
     }
 
     public function testCurlCallToModifyResponseBody()
     {
         // Remove the avatar attribute from a response
         $cb = function ($bodyAsString) {
-            $ws = json_decode($bodyAsString, true);
-            unset($ws['data']['avatar']);
-
-            return json_encode($ws);
+            return preg_replace('/404 \- Not Found/', '', $bodyAsString);
         };
 
         VCRCleaner::enable(array(
@@ -218,11 +215,11 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         ));
 
         $curl = new Curl();
-        $curl->get('https://reqres.in/api/users/2');
+        $curl->get('https://www.example.com/search');
         $curl->close();
 
         $vcrFile = $this->getCassetteContent();
 
-        $this->assertNotContains('avatar', $vcrFile);
+        $this->assertNotContains('404 - Not Found', $vcrFile);
     }
 }


### PR DESCRIPTION
I don't like the use of reflection here, but it's the only option I can see with the way php-vcr is designed. Since php-vcr doesn't see *too* much development, I'll rely on that fact that the internals of `Response` won't change 🤞

Fixes #3 