### PR TITLE
Fix/hostmatcher

### DIFF
--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -48,8 +48,7 @@ abstract class RelaxedRequestMatcher
         $firstURL = parse_url($first->getUrl());
         $secondURL = parse_url($second->getUrl());
 
-        unset($firstURL['host']);
-        unset($secondURL['host']);
+        unset($firstURL['host'], $secondURL['host'], $secondURL['query'], $firstURL['query']);
 
         return $firstURL === $secondURL;
     }

--- a/tests/VCR/RelaxedRequestMatcherTest.php
+++ b/tests/VCR/RelaxedRequestMatcherTest.php
@@ -18,12 +18,13 @@ class RelaxedRequestMatcherTest extends \PHPUnit_Framework_TestCase
 {
     public function testRelaxedRequestMatcherQueryHost()
     {
-        $actualRequest = new Request('GET', 'http://example.com/api/v1?query=users');
+        $actualRequest = new Request('GET', 'http://example.com/api/v1?query=users&foo=bar');
         $cleanRequest = new Request('GET', 'http://[]/api/v1?query=users');
 
         Config::configureOptions(array(
             'request' => array(
                 'ignoreHostname' => true,
+                'ignoreQueryFields' => array('foo'),
             ),
         ));
 


### PR DESCRIPTION
The host matcher failed when a query param was ignored.
Perhaps even just returning true is good enough here.

It will now still fail if you have changes in the protocol i.e.  https / http