### PR TITLE
Account for empty body in sanitizeResponseBody

### DIFF
--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -128,6 +128,10 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
     private function sanitizeResponseBody(array &$workspace)
     {
+        if (!isset($workspace['body'])) {
+            return;
+        }
+
         foreach (Config::getResBodyScrubbers() as $bodyScrubber) {
             $workspace['body'] = $bodyScrubber($workspace['body']);
         }


### PR DESCRIPTION
`VCRCleanerEventSubscriber::sanitizeResponseBody` is fed the working response as an array. This filters out fields that are empty. If the body is empty, it will try to access an undefined "body" index.

In `VCR\Response::toArray` method:
```php
        return array_filter(
            array(
                'status'    => $this->status,
                'headers'   => $this->getHeaders(),
                'body'      => $body
            )
        );
```

That can result in the returning array to miss some of the fields (most likely the body field).

When this gets passed to `VCRCleanerEventSubscriber::sanitizeResponseBody` in `VCRCleanerEventSubscriber::onBeforeRecord`, it will cause issue due to an undefined index.