### PR TITLE
Sanitize our headers in a case-insensitive manner

### DIFF
--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -195,8 +195,8 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $vcrFile = $this->getCassetteContent();
 
-        $this->assertNotContains('X-Cache: 404-HIT', $vcrFile);
-        $this->assertContains('X-Cache: null', $vcrFile);
+        $this->assertNotContains('X-Cache: 404-HIT', $vcrFile, '', true);
+        $this->assertContains('X-Cache: null', $vcrFile, '', true);
     }
 
     public function testCurlCallToModifyResponseBody()


### PR DESCRIPTION
According to the [HTTP spec](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), headers are case-**in**sensitive. This means we should compare our headers in a case-insensitive manner but still record them as they are when returned from the server.