### PR TITLE
Check if the header exists in the request before accessing it

### DIFF
--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -78,7 +78,13 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
         }
 
         foreach (Config::getReqIgnoredHeaders() as $header) {
-            $targetHeader = $caseInsensitiveKeys[strtolower($header)];
+            $caseInsensitiveHeader = strtolower($header);
+
+            if (!isset($caseInsensitiveKeys[$caseInsensitiveHeader])) {
+                continue;
+            }
+
+            $targetHeader = $caseInsensitiveKeys[$caseInsensitiveHeader];
 
             if ($request->hasHeader($targetHeader)) {
                 $request->setHeader($targetHeader, null);
@@ -145,6 +151,11 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
         foreach (Config::getResIgnoredHeaders() as $headerToIgnore) {
             $caseInsensitiveHeader = strtolower($headerToIgnore);
+
+            if (!isset($caseInsensitiveKeys[$caseInsensitiveHeader])) {
+                continue;
+            }
+
             $targetHeader = $caseInsensitiveKeys[$caseInsensitiveHeader];
 
             if (isset($workspace['headers'][$targetHeader])) {

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -108,6 +108,28 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('application/vcr', $vcrFile);
     }
 
+    public function testCurlCallWithSensitiveHeadersThatDontExist()
+    {
+        VCRCleaner::enable(array(
+            'request' => array(
+                'ignoreHeaders' => array('X-Api-Key'),
+            ),
+            'response' => array(
+                'ignoreHeaders' => array('X-Whatever'),
+            ),
+        ));
+
+        $curl = new Curl();
+        $curl->setHeader('X-Type', 'application/vcr');
+        $curl->get('https://www.example.com/search');
+        $curl->close();
+
+        $vcrFile = $this->getCassetteContent();
+
+        $this->assertContains('X-Type', $vcrFile);
+        $this->assertContains('application/vcr', $vcrFile);
+    }
+
     public function testCurlCallWithSensitiveUrlParametersAndHeaders()
     {
         VCRCleaner::enable(array(


### PR DESCRIPTION
Hello,

I attempted to update to 1.0.3 and started seeing the following error:

```
9) App\Jobs\Stripe\RecordDisputeTest::updatesExistingInvoiceDisputeForRepeatPayloads
ErrorException: Undefined index: x-api-key

/root/my-app/vendor/allejo/php-vcr-sanitizer/src/VCRCleanerEventSubscriber.php:81
/root/my-app/vendor/allejo/php-vcr-sanitizer/src/VCRCleanerEventSubscriber.php:46
...
```

It looks like this happens when `ignoreHeaders` contains a header name that does not exist in the request being sanitized.

This PR adds an `isset` check before accessing the header.

