### PR TITLE
[Feature] Add ability to sanitize post fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ VCRCleaner::enable(array(
 
 ### Post Field Content
 
-When making POST requests, your VCR will sometimes record the data inside of a `post_fields` parameter rather than the `body`; e.g. when `CURLOPT_POSTFIELDS` is used in cURL. In those cases, this option can be used to sanitize sensitive content. Note that unlike the `body` field, `post_fields` is an array:
+When making POST requests, your VCR will sometimes record the data inside of a `post_fields` parameter rather than the `body`; e.g. when `CURLOPT_POSTFIELDS` is used in cURL and you do not set `CURLOPT_POST` to `true`. In those cases, this option can be used to sanitize sensitive content. Note that unlike the `body` field, `post_fields` is an array:
 
 ```php
 VCRCleaner::enable(array(

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ VCRCleaner::enable(array(
 
 ### Post Field Content
 
-When making POST requests, you VCR will sometimes record the data inside of a `post_fields` parameter rather than the `body`. In those cases, this option can be used to sanitize sensitive content. Note that unlike the `body` field, `post_fields` is an array:
+When making POST requests, your VCR will sometimes record the data inside of a `post_fields` parameter rather than the `body`; e.g. when `CURLOPT_POSTFIELDS` is used in cURL. In those cases, this option can be used to sanitize sensitive content. Note that unlike the `body` field, `post_fields` is an array:
 
 ```php
 VCRCleaner::enable(array(

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ VCRCleaner::enable(array(
         headers: ~
         body: '...response body...'
 ```
+
 ## License
 
 [MIT](/LICENSE.md)

--- a/src/Config.php
+++ b/src/Config.php
@@ -64,6 +64,7 @@ abstract class Config
                 'ignoreQueryFields' => array(),
                 'ignoreHeaders'     => array(),
                 'bodyScrubbers'     => array(),
+                'postFieldScrubbers'=> array(),
             ),
             'response' => array(
                 'ignoreHeaders'     => array(),

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,6 +41,11 @@ abstract class Config
         return self::$options['request']['bodyScrubbers'];
     }
 
+    public static function getReqPostFieldScrubbers()
+    {
+        return self::$options['request']['postFieldScrubbers'];
+    }
+
     public static function getResIgnoredHeaders()
     {
         return self::$options['response']['ignoreHeaders'];

--- a/src/VCRCleaner.php
+++ b/src/VCRCleaner.php
@@ -20,10 +20,11 @@ abstract class VCRCleaner
      * ```
      * $options = [
      *   'request' => [
-     *     'ignoreHostname'    => boolean
-     *     'ignoreQueryFields' => string[]
-     *     'ignoreHeaders'     => string[]
-     *     'bodyScrubbers'     => Array<(string $body): string>
+     *     'ignoreHostname'     => boolean
+     *     'ignoreQueryFields'  => string[]
+     *     'ignoreHeaders'      => string[]
+     *     'bodyScrubbers'      => Array<(string $body): string>
+     *     'postFieldScrubbers' => Array<(array $postFields): array>
      *   ],
      *   'response' => [
      *     'ignoreHeaders'     => string[]


### PR DESCRIPTION
Some libraries using curl are using post fields. This adds the ability to sanitize the `post_fields` field that PHP-VCR records in its cassettes

I've seen [this comment](https://github.com/allejo/php-vcr-sanitizer/issues/1#issuecomment-418956001) but I've found in my usage with PHP-VCR, that using [this library](https://github.com/facebook/facebook-php-business-sdk/blob/c7bf72b1f5ca8f3fd6120544cb2541546204bf83/src/FacebookAds/Http/Adapter/CurlAdapter.php#L179), things were being put into the `post_fields` of the cassette with no way to sanitize it

Sidenote - There were no instructions on how to run the tests locally and I was unable to do so. I'm hoping that @allejo is able to provide direction on that.