### PR TITLE
Use a local web server for making cURL calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "symfony/event-dispatcher": "^2.4|^3.0|^4.0"
     },
     "require-dev": {
+        "donatj/mock-webserver": "^2.1",
         "mikey179/vfsstream": "^1.6",
         "php-curl-class/php-curl-class": "^8.0",
         "phpunit/phpunit": "^4.8|^5.0|^7.0"


### PR DESCRIPTION
Following https://github.com/allejo/php-vcr-sanitizer/pull/13#issuecomment-611890383, hitting `example.com` for test cURL calls proved to be fragile. This PR changes our unit tests to use [donatj/mock-webserver](https://github.com/donatj/mock-webserver) instead.