### PR TITLE
Wildcard headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "A set of php-vcr utilities to sanitize API requests",
     "type": "library",
     "require": {
-        "php-vcr/php-vcr": "^1.4",
-        "symfony/event-dispatcher": "^2.4|^3.0|^4.0"
+        "php-vcr/php-vcr": "^1.5",
+        "symfony/event-dispatcher": "^5.0"
     },
     "require-dev": {
         "donatj/mock-webserver": "^2.1",
@@ -12,6 +12,12 @@
         "php-curl-class/php-curl-class": "^8.0",
         "phpunit/phpunit": "^4.8|^5.0|^7.0"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/thecoderszone/php-vcr"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "allejo\\VCR\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A set of php-vcr utilities to sanitize API requests",
     "type": "library",
     "require": {
-        "php-vcr/php-vcr": "^1.5",
+        "php-vcr/php-vcr": "^1.8",
         "symfony/event-dispatcher": "^5.0"
     },
     "require-dev": {

--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -58,6 +58,11 @@ abstract class RelaxedRequestMatcher
         $secondHeaders = $second->getHeaders();
 
         foreach (Config::getReqIgnoredHeaders() as $parameter) {
+            if ($parameter === '*') {
+                $firstHeaders = null;
+                $secondHeaders = null;
+            }
+            
             unset($firstHeaders[$parameter]);
             unset($secondHeaders[$parameter]);
         }

--- a/tests/VCR/RelaxedRequestMatcherTest.php
+++ b/tests/VCR/RelaxedRequestMatcherTest.php
@@ -82,6 +82,24 @@ class RelaxedRequestMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(RequestMatcher::matchHeaders($actualRequest, $cleanRequest));
         $this->assertTrue(RelaxedRequestMatcher::matchHeaders($actualRequest, $cleanRequest));
     }
+    
+    public function testRelaxedRequestMatcherWildcardHeaders()
+    {
+        $actualRequest = new Request('GET', 'http://example.com/api/v1', array(
+            'X-API-KEY' => 'SomethingSensitive',
+            'X-Header'  => 'something-not-secret',
+        ));
+        $cleanRequest  = new Request('GET', 'http://example.com/api/v1', array());
+        
+        Config::configureOptions(array(
+            'request' => array(
+                'ignoreHeaders' => array('*'),
+            ),
+        ));
+        
+        $this->assertFalse(RequestMatcher::matchHeaders($actualRequest, $cleanRequest));
+        $this->assertTrue(RelaxedRequestMatcher::matchHeaders($actualRequest, $cleanRequest));
+    }
 
     public function testRelaxedRequestMatcherBody()
     {

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -133,6 +133,28 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('X-Type', $vcrFile);
         $this->assertContains('application/vcr', $vcrFile);
     }
+    
+    public function testCurlCallWithWildcardSensitiveHeaders()
+    {
+        VCRCleaner::enable(array(
+            'request' => array(
+                'ignoreHeaders' => array('*'),
+            ),
+        ));
+        
+        $curl = new Curl();
+        $curl->setHeader('X-Api-Key', 'SuperToast');
+        $curl->setHeader('X-Type', 'application/vcr');
+        $curl->get($this->getApiUrl());
+        $curl->close();
+        
+        $vcrFile = $this->getCassetteContent();
+        
+        $this->assertContains('X-Api-Key', $vcrFile);
+        $this->assertNotContains('SuperToast', $vcrFile);
+        $this->assertContains('X-Type', $vcrFile);
+        $this->assertNotContains('application/vcr', $vcrFile);
+    }
 
     public function testCurlCallWithSensitiveHeadersThatDontExist()
     {
@@ -282,6 +304,25 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotContains('X-Cache: 404-HIT', $vcrFile, '', true);
         $this->assertContains('X-Cache: null', $vcrFile, '', true);
+    }
+    
+    public function testCurlCallToModifyWildcardResponseHeaders()
+    {
+        VCRCleaner::enable(array(
+            'response' => array(
+                'ignoreHeaders' => array(
+                    '*',
+                ),
+            ),
+        ));
+        
+        $curl = new Curl();
+        $curl->get($this->getApiUrl());
+        $curl->close();
+        
+        $vcrFile = $this->getCassetteContent();
+        
+        $this->assertNotContains('X-Cache: 404-HIT', $vcrFile, '', true);
     }
 
     public function testCurlCallToModifyResponseBody()


### PR DESCRIPTION
Added wildcard header sanitization to remove all request and response headers if configured.

Usage
```
VCRCleaner::enable(array(
   'request' => array(
       'ignoreHeaders' => array('*'),
   ),
   'response' => array(
       'ignoreHeaders' => array('*'),
   ),
));