### PR TITLE
Wildcard headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ VCRCleaner::enable(array(
        ),
    ),
    'response' => array(
-       'ignoreHeaders' => array(),
+       'ignoreHeaders' => array('*'),
        'bodyScrubbers' => array(),
    ),
 ));
@@ -78,7 +78,7 @@ This library allows your sanitize both the Request and Response sections of your
 
 - `request.ignoreHostname` - When set to true, the hostname in URLs inside of the Request will be replaced with `[]` in the `url` field and the `Host` in the headers will be set to null.
 - `request.ignoreQueryFields` - Define which GET parameters in your URL to completely strip out of your recordings.
-- `request.ignoreHeaders` - Define the headers in your recording that will automatically be set to null in your recordings
+- `request.ignoreHeaders` - Define the headers in your recording that will automatically be set to null in your recordings. A wildcard may be used to strip all headers from the request.
 - `request.bodyScrubbers` - An array of callbacks that will have the request body available as a string. Each callback **must** return the modified body. The callbacks are called consecutively in the order they appear in this array and the value from one callback propagates to the next.
 - `request.postFieldScrubbers` - An array of callbacks that will have the request post fields available as an array. Each callback **must** return the modified post fields array. The callbacks are called consecutively in the order they appear in this array and the value from one callback propagates to the next.
 
@@ -86,7 +86,7 @@ This library allows your sanitize both the Request and Response sections of your
 
 The php-vcr library does not officially support modifying its responses so this library uses reflection to modify the contents of responses. While this feature is officially supported by *this* project, bear with us if this feature were to break due to the php-vcr changing its internals.
 
-- `response.ignoreHeaders` - The same as `request.ignoreHeaders` but for your response body instead.
+- `response.ignoreHeaders` - The same as `request.ignoreHeaders` but for your response body instead. A wildcard may be used to strip all headers from the response.
 - `response.bodyScrubbers` - The same as `request.bodyScrubbers` but for your response body instead.
 
 ### Disabling the Sanitizer

--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -61,6 +61,8 @@ abstract class RelaxedRequestMatcher
             if ($parameter === '*') {
                 $firstHeaders = null;
                 $secondHeaders = null;
+                
+                break;
             }
             
             unset($firstHeaders[$parameter]);

--- a/src/RelaxedRequestMatcher.php
+++ b/src/RelaxedRequestMatcher.php
@@ -58,6 +58,11 @@ abstract class RelaxedRequestMatcher
         $secondHeaders = $second->getHeaders();
 
         foreach (Config::getReqIgnoredHeaders() as $parameter) {
+            if ($parameter === '*') {
+                $firstHeaders = null;
+                $secondHeaders = null;
+            }
+            
             unset($firstHeaders[$parameter]);
             unset($secondHeaders[$parameter]);
         }

--- a/tests/VCR/RelaxedRequestMatcherTest.php
+++ b/tests/VCR/RelaxedRequestMatcherTest.php
@@ -82,6 +82,24 @@ class RelaxedRequestMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(RequestMatcher::matchHeaders($actualRequest, $cleanRequest));
         $this->assertTrue(RelaxedRequestMatcher::matchHeaders($actualRequest, $cleanRequest));
     }
+    
+    public function testRelaxedRequestMatcherWildcardHeaders()
+    {
+        $actualRequest = new Request('GET', 'http://example.com/api/v1', array(
+            'X-API-KEY' => 'SomethingSensitive',
+            'X-Header'  => 'something-not-secret',
+        ));
+        $cleanRequest  = new Request('GET', 'http://example.com/api/v1', array());
+        
+        Config::configureOptions(array(
+            'request' => array(
+                'ignoreHeaders' => array('*'),
+            ),
+        ));
+        
+        $this->assertFalse(RequestMatcher::matchHeaders($actualRequest, $cleanRequest));
+        $this->assertTrue(RelaxedRequestMatcher::matchHeaders($actualRequest, $cleanRequest));
+    }
 
     public function testRelaxedRequestMatcherBody()
     {

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -133,6 +133,28 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('X-Type', $vcrFile);
         $this->assertContains('application/vcr', $vcrFile);
     }
+    
+    public function testCurlCallWithWildcardSensitiveHeaders()
+    {
+        VCRCleaner::enable(array(
+            'request' => array(
+                'ignoreHeaders' => array('*'),
+            ),
+        ));
+        
+        $curl = new Curl();
+        $curl->setHeader('X-Api-Key', 'SuperToast');
+        $curl->setHeader('X-Type', 'application/vcr');
+        $curl->get($this->getApiUrl());
+        $curl->close();
+        
+        $vcrFile = $this->getCassetteContent();
+        
+        $this->assertContains('X-Api-Key', $vcrFile);
+        $this->assertNotContains('SuperToast', $vcrFile);
+        $this->assertContains('X-Type', $vcrFile);
+        $this->assertNotContains('application/vcr', $vcrFile);
+    }
 
     public function testCurlCallWithSensitiveHeadersThatDontExist()
     {
@@ -282,6 +304,25 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotContains('X-Cache: 404-HIT', $vcrFile, '', true);
         $this->assertContains('X-Cache: null', $vcrFile, '', true);
+    }
+    
+    public function testCurlCallToModifyWildcardResponseHeaders()
+    {
+        VCRCleaner::enable(array(
+            'response' => array(
+                'ignoreHeaders' => array(
+                    '*',
+                ),
+            ),
+        ));
+        
+        $curl = new Curl();
+        $curl->get($this->getApiUrl());
+        $curl->close();
+        
+        $vcrFile = $this->getCassetteContent();
+        
+        $this->assertNotContains('X-Cache: 404-HIT', $vcrFile, '', true);
     }
 
     public function testCurlCallToModifyResponseBody()


### PR DESCRIPTION
Added wildcard header sanitization to remove all request and response headers if configured.

Usage
```
VCRCleaner::enable(array(
   'request' => array(
       'ignoreHeaders' => array('*'),
   ),
   'response' => array(
       'ignoreHeaders' => array('*'),
   ),
));