### PR TITLE
Check this field is set first

### DIFF
--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -195,13 +195,16 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
 
         $this->sanitizeCurlInfoURL($workspace);
 
-        // `curl_info` has a duplicate of Request headers too in the `request_header` field
-        $splitHeaders = preg_split('/(\r\n)|(\n)/', $workspace['curl_info']['request_header']);
+        // Check if this field is set, because it may not be
+        if (array_key_exists('request_header', $workspace['curl_info'])) {
+            // `curl_info` has a duplicate of Request headers too in the `request_header` field
+            $splitHeaders = preg_split('/(\r\n)|(\n)/', $workspace['curl_info']['request_header']);
 
-        $this->sanitizeCurlInfoRequestHeaderURL($splitHeaders);
-        $this->sanitizeCurlInfoRequestHeaders($splitHeaders);
+            $this->sanitizeCurlInfoRequestHeaderURL($splitHeaders);
+            $this->sanitizeCurlInfoRequestHeaders($splitHeaders);
 
-        $workspace['curl_info']['request_header'] = implode('\r\n', $splitHeaders);
+            $workspace['curl_info']['request_header'] = implode('\r\n', $splitHeaders);
+        }
     }
 
     /**


### PR DESCRIPTION
I was updating some VCR files, and I noticed we had this problem occur:

```php
ErrorException: Undefined index: request_header

/var/www/vendor/allejo/php-vcr-sanitizer/src/VCRCleanerEventSubscriber.php:199
/var/www/vendor/allejo/php-vcr-sanitizer/src/VCRCleanerEventSubscriber.php:58
/var/www/vendor/symfony/event-dispatcher/EventDispatcher.php:230
/var/www/vendor/symfony/event-dispatcher/EventDispatcher.php:59
/var/www/vendor/php-vcr/php-vcr/src/VCR/Videorecorder.php:106
```

It may be related to the fact that we updated all packages very recently.

So I had a look, and making the change in this PR fixed the issue for us. I also did a dump of the curl info in $workspace to make sure it is actually set in general, and everything else looked fine.