### PR TITLE
fix: no longer redacts Host if ignored

### DIFF
--- a/src/VCRCleanerEventSubscriber.php
+++ b/src/VCRCleanerEventSubscriber.php
@@ -110,9 +110,11 @@ class VCRCleanerEventSubscriber implements EventSubscriberInterface
     private function sanitizeRequestHost(Request $request)
     {
         $newUrl = $this->deleteHostFromURL($request->getUrl());
-
         $request->setUrl($newUrl);
-        $request->setHeader('Host', '');
+
+        if (Config::ignoreReqHostname()) {
+            $request->setHeader('Host', '');
+        }
     }
 
     private function sanitizeRequestUrl(Request $request)

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -273,6 +273,22 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotRegExp(sprintf("/^\s+(?<!local_ip:)\s*%s/", preg_quote($this->server->getHost(), '/')), $vcrFile);
         $this->assertContains(sprintf('http://[]:%d/search', $this->server->getPort()), $vcrFile);
+        $this->assertContains("Host: ''", $vcrFile);
+    }
+
+    public function testCurlCallWithoutRedactedHostname()
+    {
+        VCRCleaner::enable(array(
+            'request' => array(
+                'ignoreHostname' => false,
+            ),
+        ));
+
+        $this->curl->get($this->getApiUrl());
+
+        $vcrFile = $this->getCassetteContent();
+
+        $this->assertNotContains("Host: ''", $vcrFile);
     }
 
     public function testCurlCallToModifyResponseHeaders()


### PR DESCRIPTION
Previously, there was no check to ensure the user wanted to redact the `Host` field in the request headers and would redact it to `Host: ''` regardless if the user specified `ignoreHostname` or not.

This PR ensures the user also wants to redact the Host by checking for this config option, redacting if true, leaving it in place if false.

I've updated the unit tests to ensure this logic works correctly for either case.

Closes #22 