### PR TITLE
Add support for Symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.4",
         "php-vcr/php-vcr": "^1.4",
-        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0"
+        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
Allows to install `symfony/event-dispatcher` 6.x