### PR TITLE
Feature/php 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+                php-versions: ['8.0', '8.1', '8.2']
                 os: [ubuntu-latest]
                 dependencies: ['install']
 
@@ -59,7 +59,7 @@ jobs:
               run: composer test
 
             - name: Push to Scrutinizer
-              if: matrix.php-versions == '7.4' && runner.os == 'Linux' && matrix.dependencies == 'install'
+              if: matrix.php-versions == '8.2' && runner.os == 'Linux' && matrix.dependencies == 'install'
               run: |
                   composer coverage
                   wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,16 @@
     "description": "Bring privacy to php-vcr by excluding API keys, passwords, and credentials from your recordings",
     "type": "library",
     "require": {
-        "php": ">=5.4",
-        "php-vcr/php-vcr": "^1.4",
-        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0"
+        "php": ">=8.0",
+        "covergenius/php-vcr": "^1.9",
+        "symfony/event-dispatcher": "^6.0"
     },
     "require-dev": {
         "ext-curl": "*",
         "donatj/mock-webserver": "^2.1",
         "mikey179/vfsstream": "^1.6",
-        "php-curl-class/php-curl-class": "^8.0",
-        "phpunit/phpunit": "^4.8|^5.0|^7.0"
+        "php-curl-class/php-curl-class": "^9.0",
+        "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="tests/bootstrap.php"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="tests/bootstrap.php">
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="PHP VCR Sanitizer Test Suite">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -24,7 +24,7 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
     /** @var Curl */
     private $curl;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $root = vfsStream::setup('root');
 
@@ -45,13 +45,13 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         VCR::insertCassette('cassette.yml');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         VCR::eject();
         VCR::turnOff();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         // Clear the file
         file_put_contents(vfsStream::url('root/fixtures/cassette.yml'), '');
@@ -78,7 +78,7 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->curl = new Curl($this->server->getServerRoot());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         // Remove any settings from tests
         VCRCleaner::enable(array());

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -195,13 +195,13 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $vcrFile = $this->getCassetteContent();
 
-        $this->assertNotContains('SuperToast', $vcrFile);
-        $this->assertNotContains('somethingSensitive', $vcrFile);
-        $this->assertNotContains('apiKey', $vcrFile);
-        $this->assertContains('q=keyword', $vcrFile);
-        $this->assertContains('X-Api-Key', $vcrFile);
-        $this->assertContains('X-Type', $vcrFile);
-        $this->assertContains('application/vcr', $vcrFile);
+        $this->assertStringNotContainsString('SuperToast', $vcrFile);
+        $this->assertStringNotContainsString('somethingSensitive', $vcrFile);
+        $this->assertStringNotContainsString('apiKey', $vcrFile);
+        $this->assertStringContainsString('q=keyword', $vcrFile);
+        $this->assertStringContainsString('X-Api-Key', $vcrFile);
+        $this->assertStringContainsString('X-Type', $vcrFile);
+        $this->assertStringContainsString('application/vcr', $vcrFile);
     }
 
     public function testCurlCallWithSensitiveBody()

--- a/tests/VCR/VCRCleanerEventSubscriberTest.php
+++ b/tests/VCR/VCRCleanerEventSubscriberTest.php
@@ -60,6 +60,8 @@ class VCRCleanerEventSubscriberTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($newFile);
 
         $this->server = new MockWebServer();
+        $this->server->start();
+
         $this->server->setResponseOfPath(
             '/search',
             new Response(


### PR DESCRIPTION
Due to PHP 8, there are some backwards incompatible changes on function definitions, so I think it's best to just tag a new version, and remove older deps.

Currently I'm working through this issue to be able to test properly;
```
donatj\MockWebServer\Exceptions\ServerException: Failed to start server. Is something already running on port 36339?
```

If anyone has any ideas let me know. I can run the command fine locally and even using backticks from PHP, but for some reason by default, the mock webserver doesnt keep itself open, and reports no errors whatsoever.

This can potentially be written without the webserver, just using laravel's or phpunit's helpers for web requests, but a bigger rewrite.