### PR TITLE
Drop support for PHP < 7.1, update PHPUnit to work with PHP 8+, update Symfony requirements to latest supported LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,16 @@ jobs:
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
 
-            - name: Install dependencies
-              run: composer ${{ matrix.dependencies }} --prefer-dist --no-progress --no-suggest
+            - name: Install dependencies for PHP
+              run: |
+                  composer install --prefer-dist --no-progress
+
+            - name: Patch unit tests to work against PHPUnit 7.5, if needed
+              if: matrix.php-versions == '7.1' || matrix.php-versions == '7.2'
+              run: |
+                sed -i -E 's/assertDoesNotMatchRegularExpression/assertNotRegExp/gm' tests/VCR/VCRCleanerEventSubscriberTest.php
+                sed -i -E 's/assertStringNotContainsString/assertNotContains/gm' tests/VCR/VCRCleanerEventSubscriberTest.php
+                sed -i -E 's/assertStringContainsString/assertContains/gm' tests/VCR/VCRCleanerEventSubscriberTest.php
 
             - name: Show Installed Dependencies
               run: composer show

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,13 @@ on:
 
 jobs:
     tests:
-        name: PHP ${{ matrix.php-versions }} on ${{ matrix.os }} w/ ${{ matrix.dependencies }}
+        name: PHP ${{ matrix.php-versions }} on ${{ matrix.os }}
         runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
-                php-versions: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+                php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
                 os: [ubuntu-latest]
-                dependencies: ['install']
 
         steps:
             - name: Checkout
@@ -26,7 +25,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-versions }}
-                  extensions: curl, soap
+                  extensions: curl, json, soap, sockets
                   coverage: xdebug
 
             - name: Setup Problem Matchers for PHP

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 .idea/
 .php_cs
 .php_cs.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -9,10 +9,12 @@
     },
     "require-dev": {
         "ext-curl": "*",
+        "ext-json": "*",
+        "ext-sockets": "*",
         "donatj/mock-webserver": "^2.1",
         "mikey179/vfsstream": "^1.6",
-        "php-curl-class/php-curl-class": "^8.0",
-        "phpunit/phpunit": "^4.8|^5.0|^7.0"
+        "php-curl-class/php-curl-class": "^9.0",
+        "phpunit/phpunit": "^7.5|^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=7.1.3",
         "php-vcr/php-vcr": "^1.4",
-        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0"
+        "symfony/event-dispatcher": "^4.0|^5.0|^6.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Bring privacy to php-vcr by excluding API keys, passwords, and credentials from your recordings",
     "type": "library",
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1.3",
         "php-vcr/php-vcr": "^1.4",
         "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="tests/bootstrap.php"
->
-    <testsuites>
-        <testsuite name="PHP VCR Sanitizer Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="tests/bootstrap.php">
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHP VCR Sanitizer Test Suite">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/VCR/RelaxedRequestMatcherTest.php
+++ b/tests/VCR/RelaxedRequestMatcherTest.php
@@ -11,10 +11,11 @@ namespace allejo\VCR\Tests;
 
 use allejo\VCR\Config;
 use allejo\VCR\RelaxedRequestMatcher;
+use PHPUnit\Framework\TestCase;
 use VCR\Request;
 use VCR\RequestMatcher;
 
-class RelaxedRequestMatcherTest extends \PHPUnit_Framework_TestCase
+class RelaxedRequestMatcherTest extends TestCase
 {
     public function testRelaxedRequestMatcherQueryHostEnabled()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,11 +8,3 @@
  */
 
 require __DIR__ . '/../vendor/autoload.php';
-
-if (PHP_VERSION_ID >= 70100) {
-    if (!class_exists('\PHPUnit_Framework_TestCase')) {
-        class PHPUnit_Framework_TestCase extends \PHPUnit\Framework\TestCase
-        {
-        }
-    }
-}


### PR DESCRIPTION
Some minor sorcery and troubleshooting was needed. And I didn't want to drop support for PHP 7.x quite yet considering Symfony LTS still supports it, so I merged the changes by @yethee and @specialtactics into this branch.

closes #24
closes #25